### PR TITLE
remove udev restart from postinst

### DIFF
--- a/TI3DToF/CMakeLists.txt
+++ b/TI3DToF/CMakeLists.txt
@@ -141,7 +141,6 @@ set_target_properties(ti3dtof PROPERTIES
 IF(LINUX)
   set(CPACK_COMPONENTS_ALL ti3dtof)
   set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Support libraries for ToF depth camera from Texas Instruments")
-  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_CURRENT_SOURCE_DIR}/debian/postinst;${CMAKE_CURRENT_SOURCE_DIR}/debian/postrm;")
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "libvoxel (>= ${VOXEL_VERSION})")
   create_cpack_config(libti3dtof ${VOXEL_VERSION})
 


### PR DESCRIPTION
Suppress reloading `udev` rules as we are inside a container